### PR TITLE
Fix InsertDocument containing a picture resulting in IOException

### DIFF
--- a/src/DocXCore/DocX.cs
+++ b/src/DocXCore/DocX.cs
@@ -1431,8 +1431,13 @@ namespace Novacode
                     return;
             }
             String remote_Id = remote_rel.Id;
-
-            String remote_hash = ComputeMD5HashString(remote_pp.GetStream());
+            
+            String remote_hash;
+            using (var remote_pp_stream = remote_pp.GetStream())
+            {
+                remote_hash = ComputeMD5HashString(remote_pp_stream);
+            }   
+            
             var image_parts = package.GetParts().Where(pp => pp.ContentType.Equals(contentType));
 
             bool found = false;


### PR DESCRIPTION
Add a fix for an IOException that occured when you tried to merge documents that contained pictures. The IOException was thrown because the code tried to open a stream for the picture, while another stream of the same picture was still open.