### PR TITLE
Fix another IOException on merging images

### DIFF
--- a/src/DocXCore/DocX.cs
+++ b/src/DocXCore/DocX.cs
@@ -1443,7 +1443,12 @@ namespace Novacode
             bool found = false;
             foreach (var part in image_parts)
             {
-                String local_hash = ComputeMD5HashString(part.GetStream());
+                String local_hash;
+                using (var part_stream = part.GetStream())
+                {
+                    local_hash = ComputeMD5HashString(part_stream);
+                }
+                    
                 if (local_hash.Equals(remote_hash))
                 {
                     // This image already exists in this document.


### PR DESCRIPTION
Apparently the image in the example code didn't have multiple image parts or something like that, but my application does. Which gave me the same IOException as I fixed yesterday.
This was the only GetStream() left in DocX that wasn't surrounded by a using statement.