### PR TITLE
Image handling on Unix systems.

### DIFF
--- a/src/DocXCore/DocX.cs
+++ b/src/DocXCore/DocX.cs
@@ -3392,7 +3392,7 @@ namespace Novacode
                         {
                             string imagePartUri = Path.Combine(Path.GetDirectoryName(relsPart.Uri.ToString()),
                                 attribute.Value);
-                            imagePartUri = Path.GetFullPath(imagePartUri.Replace("\\_rels", string.Empty));
+                            imagePartUri = Path.GetFullPath(imagePartUri.Replace("\\_rels", string.Empty).Replace("/_rels", string.Empty));
                             imagePartUri = imagePartUri.Replace(Path.GetFullPath("\\"), string.Empty).Replace("\\", "/");
 
                             if (!imagePartUri.StartsWith("/"))


### PR DESCRIPTION
`/_rels` path segment was not replaced on Unix systems since it does not match with the Windows path separator in `\_rels`.