### PR TITLE
Fix bulleted list getting numbered when using an existing document

### DIFF
--- a/src/DocXCore/List.cs
+++ b/src/DocXCore/List.cs
@@ -227,7 +227,10 @@ namespace Novacode
 
             // If the internal document contains no /word/numbering.xml create one.
             if (!Document.package.PartExists(numberingUri))
+            {
                 Document.numbering = HelperFunctions.AddDefaultNumberingXml(Document.package);
+                Document.numberingPart = Document.package.GetPart(numberingUri);
+            }
         }
     }
 }


### PR DESCRIPTION
Hi, 
I fixed an issue where lists always got numbered, even if it's an bulleted list.
This problem occured whenever you start a bulleted list from an existing document. (using DocX.Load)

Could you please merge this request? :-)
